### PR TITLE
Add CI=false to build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	},
 	"scripts": {
 		"start": "react-scripts start",
-		"build": "react-scripts build",
+		"build": "CI=false && react-scripts build",
 		"test:chrome": "cypress run --browser chrome",
 		"test:firefox": "cypress run --browser firefox",
 		"test:edge": "cypress run --browser edge",


### PR DESCRIPTION
[This prevents warnings being considered as errors
](https://stackoverflow.com/questions/62663451/treating-warnings-as-errors-because-process-env-ci-true-failed-to-compile)
