### PR TITLE
Use boxSizing to keep padding inside width

### DIFF
--- a/src/components/navigation/Footer.js
+++ b/src/components/navigation/Footer.js
@@ -12,15 +12,21 @@ export default function Footer() {
 			position: "fixed",
 			left: "0",
 			bottom: "0",
-			maxHeight: "30px",
+			maxHeight: "40px",
 			width: "100%",
-			padding: "5px",
+			WebkitBoxSizing: "border-box",
+			MozBoxSizing: "border-box",
+			boxSizing: "border-box",
+			padding: 5
 		},
 		phantom: {
 			display: "block",
-			maxHeight: "30px",
+			maxHeight: "40px",
 			width: "100%",
-			padding: "5px",
+			WebkitBoxSizing: "border-box",
+			MozBoxSizing: "border-box",
+			boxSizing: "border-box",
+			padding: 5
 		},
 	})
 


### PR DESCRIPTION
Why?
Adding padding of 5px to the Footer component (so that the text is further from the borders) is causing the width of the component to consistently expand past the viewport (because the padding increases the 100% width)  - this PR eliminates that
![image](https://user-images.githubusercontent.com/26544538/215343027-27bb71dd-b8ca-44ef-8fb9-4c40a645cc6b.png)


What?

- Use the box-sizing CSS property (and all the variants for different browsers) to include padding within the width and height of the element 
- Adjust the maxHeight of the component to accomodate for the padding

![image](https://user-images.githubusercontent.com/26544538/215343166-b04ea5fe-5666-4eca-814d-c7c8c0686640.png)
