### PR TITLE
Ft06 add mix data to similar colours

### DIFF
--- a/src/components/common/ColourCard.js
+++ b/src/components/common/ColourCard.js
@@ -11,9 +11,21 @@ colourHex: hex code for colour, used for both light title and header background
 artistName: Name of artist in bold
 colourName: Worded name of colour in light
 date: date of mix in light
+mini: true/false - if true, use smaller version of component
 */
 
 export default function ColourCard(props) {
+	//variables for size of component - reduces if mini = true
+	var minHeightHeader = 300
+	var minHeight = 480
+	var minWidth = 275
+
+	if(props.mini == true){
+		minHeightHeader = 100
+		minHeight = 170
+		minWidth = 90
+	}
+
 	const useStyles = makeStyles({
 		title: {
 			fontFamily: "HelveticaBold",
@@ -31,11 +43,11 @@ export default function ColourCard(props) {
 			padding: 3,
 		},
 		header: {
-			minHeight: 300,
+			minHeight: minHeightHeader,
 		},
 		root: {
-			minWidth: 275,
-			minHeight: 480,
+			minWidth: minWidth,
+			minHeight: minHeight,
 			maxWidth: 350,
 			padding: 0,
 			margin: 25,
@@ -72,4 +84,5 @@ ColourCard.propTypes = {
 	colourName: PropTypes.string,
 	artistName: PropTypes.string,
 	date: PropTypes.string,
+	mini: PropTypes.bool
 }

--- a/src/components/pages/ColourMatch.js
+++ b/src/components/pages/ColourMatch.js
@@ -36,12 +36,12 @@ export default function ColourMatch(){
 
 	useEffect(() => { //retrieve list of similar colours 
 		let validHex = hexyjs.isHex(`${colour}`)
-		if(colourList.length > 0 && validHex && colour.length == 6){
-			let sortedColours = getSimilarColours(colourList, colour, parseFloat(maxDiff), 10)
+		if(colourList.length > 0 && validHex && colour.length == 6 && mixData.data){
+			let sortedColours = getSimilarColours(colourList, colour, parseFloat(maxDiff), 10, mixData)
 			console.log(sortedColours)
 			setSimilarColours(sortedColours)
 		}
-	}, [colourList, colour, maxDiff])
+	}, [colourList, colour, maxDiff, mixData])
 
 
 	//functions 

--- a/src/components/pages/ColourMatch.js
+++ b/src/components/pages/ColourMatch.js
@@ -125,10 +125,14 @@ export default function ColourMatch(){
 					>
 						{similarColours.map((colour) => (
 							
-							<Grid key={colour.colour} item xs={4} sm={3}>
-								<Paper className={classes.colourPaper} style={{backgroundColor: `#${colour.colour}`}}>
-									<Typography style={{color:colour.textShade}}>{`#${colour.colour}`}</Typography>
-								</Paper>
+							<Grid key={colour.colour} item xs={12} md={6}>
+								<ColourCard
+									colourName={`${colour.mixData.colourName}`}
+									artistName={`${colour.mixData.artist}`}
+									colourHex={`${colour.mixData.colourHex}`}
+									date={`#${colour.mixData.date}`}
+									mini={true}
+								/>
 							</Grid>
 						))}	
 					</Grid>	

--- a/src/components/pages/ColourMatch.js
+++ b/src/components/pages/ColourMatch.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { makeStyles } from "@material-ui/core/styles"
-import {Grid, TextField, Typography, Paper}  from "@material-ui/core"
+import { Link } from "react-router-dom"
+import {Grid, TextField}  from "@material-ui/core"
 import ColourCard from "../common/ColourCard"
 import { getAllocatedColours, getSimilarColours } from "../../js/utils/colourMatch"
 import PropTypes from "prop-types"
@@ -126,13 +127,18 @@ export default function ColourMatch(){
 						{similarColours.map((colour) => (
 							
 							<Grid key={colour.colour} item xs={12} md={6}>
-								<ColourCard
-									colourName={`${colour.mixData.colourName}`}
-									artistName={`${colour.mixData.artist}`}
-									colourHex={`${colour.mixData.colourHex}`}
-									date={`#${colour.mixData.date}`}
-									mini={true}
-								/>
+								<Link
+									to={{ pathname: `/Mix/${colour.mixData.id}` }}
+									style={{ textDecoration: "none" }}
+								>
+									<ColourCard
+										colourName={`${colour.mixData.colourName}`}
+										artistName={`${colour.mixData.artist}`}
+										colourHex={`${colour.mixData.colourHex}`}
+										date={`#${colour.mixData.date}`}
+										mini={true}
+									/>
+								</Link>
 							</Grid>
 						))}	
 					</Grid>	

--- a/src/js/utils/colourMatch.js
+++ b/src/js/utils/colourMatch.js
@@ -12,11 +12,12 @@ export function getAllocatedColours(mixData){//flatten and output a list of colo
 	return colours
 }
 
-export function getSimilarColours(colourList, inputColour, maxDifference=100, maxColours=5){
+export function getSimilarColours(colourList, inputColour, maxDifference=100, maxColours=5, mixData=null){
 /*
 	Returns a list of colours similar to inputColour from an input colourList
 	maxDifference is the max difference in scale the colours picked can be (max is 1)
 	maxColours is the max number of colours in the list 
+	if mixData is populated - it will pick out the mix information for each colour and include it in the data
 */
 
 	let selectedColours = []
@@ -26,7 +27,11 @@ export function getSimilarColours(colourList, inputColour, maxDifference=100, ma
 		let colourDiff = cd.compare(colour, inputColour)
 		let colourHex = `#${colour}`
 		let textShade = getTextShade(colourHex)
-		return {"colourDiff": colourDiff, "colour": colour, "textShade": textShade}
+		let data = null
+		if(mixData){
+			data = findMixData(mixData, colour)
+		}
+		return {"colourDiff": colourDiff, "colour": colour, "textShade": textShade, "mixData": data}
 	})
 
 	sortedColours.sort((a,b) => {
@@ -40,6 +45,20 @@ export function getSimilarColours(colourList, inputColour, maxDifference=100, ma
 	})
 
 	return selectedColours
+}
+
+function findMixData(data, colourHex){
+	data = data.data
+	let selectedData = data.filter((mix) => {
+		return mix.colourHex == `#${colourHex}`
+	})
+	
+	if(selectedData){
+		return selectedData[0]
+	}
+	else{
+		return null
+	}
 }
 
 export function getTextShade(colour) {


### PR DESCRIPTION
Why
- When listing out similar colours with the getSimilarColours feature - we need to be able to actually access the data of those mixes also , so added a functionality to retrieve this data also


What
- Added an optional param to getSimilarColours called mixData (default: null) which, if provided with mixData.json will attach the individual mixData to each colour (caveat - this relies on hex codes only being used once)
- Added another prop to ColourCard: mini - a boolean that discerns whether to use a smaller, more square dimension version of ColourCard or the regular one 
- Added functionality to /ColourMatch page to show mini versions of the ColourCard for each colour selected with a link to the mix

ToDo
- Fix back button functionality to actually go back