### PR TITLE
Utilize useHistory to Back Button

### DIFF
--- a/src/components/common/BackButton.js
+++ b/src/components/common/BackButton.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Image from "material-ui-image"
+import { makeStyles } from "@material-ui/core/styles"
+import { useHistory } from "react-router-dom";
+
+export default function BackButton() {
+	
+	const iconUrl = "https://firebasestorage.googleapis.com/v0/b/colours-project.appspot.com/o/images%2Fbackicon.png?alt=media&token=ccf1bdfd-e667-4891-af5e-707a1304ae78"
+	let history = useHistory()
+	const useStyles = makeStyles({
+		root: {},
+		icon: {
+			maxHeight: 75,
+			maxWidth: 75
+		}
+	})
+
+	const classes = useStyles()
+	
+	return (
+		<div>
+			<Image
+				onClick={() => history.goBack()}
+				src={iconUrl}
+				className={classes.icon}
+				style={{ left: "30%" }}
+			/>
+		</div>
+	);
+	
+}

--- a/src/components/pages/Mix.js
+++ b/src/components/pages/Mix.js
@@ -4,6 +4,7 @@ import { makeStyles } from "@material-ui/core/styles"
 import Grid from "@material-ui/core/Grid"
 import MixBoxMobile from "../common/MixBoxMobile"
 import MixNavBar from "../navigation/MixNavBar"
+import BackButton from "../common/BackButton"
 import Image from "material-ui-image"
 import { fadeInDown } from "react-animations"
 import Radium, { StyleRoot } from "radium"
@@ -127,13 +128,7 @@ export default function Mix() {
 							spacing={0}>
 							<Grid item xs={4} md={5} />
 							<Grid item xs={2}>
-								<Link to={{ pathname: "/" }}>
-									<Image
-										src="https://firebasestorage.googleapis.com/v0/b/colours-project.appspot.com/o/images%2Fbackicon.png?alt=media&token=ccf1bdfd-e667-4891-af5e-707a1304ae78"
-										className={classes.icon}
-										style={{ left: "30%" }}
-									/>
-								</Link>
+								<BackButton/>
 							</Grid>
 							<Grid item xs={5} />
 						</Grid>


### PR DESCRIPTION
Why?
So that as the app gets more routes, we have a reliable way to go to the previous page without user clicking back on browser

What?

- Create re-usable component for back button
- Use useHistory.goBack() for link instead of the absolute path to index